### PR TITLE
fix(store): allow a generic reducer (ngrx/platform #2996)

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,7 +22,7 @@ export interface ImmerOnReducer<State, AC extends ActionCreator[]> {
  * Immer wrapper around `on` to mutate state
  */
 export function immerOn<State, Creators extends ActionCreator[]>(
-	...args: [...creators: Creators, reducer: ImmerOnReducer<State, Creators>]
+	...args: [...creators: Creators, reducer: ImmerOnReducer<State extends infer S ? S : never, Creators>]
 ): ReducerTypes<State, Creators> {
 	const reducer = (args.pop() as Function) as ActionReducer<State>;
 	return (on as any)(...(args as ActionCreator[]), immerReducer(reducer));


### PR DESCRIPTION
To solve `immerOn` type issues I followed the solution used in https://github.com/ngrx/platform/pull/2996 to fix generic reducer type mismatch with ngrx/platform.

![image](https://user-images.githubusercontent.com/8835207/173066085-7672288b-9b50-439a-81d0-000f7d8b7cb5.png)

![image](https://user-images.githubusercontent.com/8835207/173066180-a86b2e4d-bd16-4507-86e6-b1e4ec3db106.png)
